### PR TITLE
Handle quit by timeout

### DIFF
--- a/Network/data/DisconnectData.hpp
+++ b/Network/data/DisconnectData.hpp
@@ -20,7 +20,7 @@ namespace Network::data {
          * @see Network::Packet::connectData
          * @see Network::Packet::disconnectData
          */
-        struct ConnectData {
+        struct DisconnectData {
             public:
                 /**
                  * @brief The id of the player that disconnected.

--- a/client/ecs/Core.hpp
+++ b/client/ecs/Core.hpp
@@ -131,6 +131,8 @@ namespace ECS {
              */
             void _handlerBossState(Network::Packet &packet, const udp::endpoint &endpoint);
             void _handlerScore(Network::Packet &packet, const udp::endpoint &endpoint);
+            void _handlerDisconnect(Network::Packet &packet, const udp::endpoint &endpoint);
+
             void _createBossLaser(const std::string& entityName, float x, float y);
 
             /**

--- a/server/ClientManager.cpp
+++ b/server/ClientManager.cpp
@@ -85,7 +85,7 @@ bool RType::ClientManager::cleanupInactiveClients(RType::Server &server)
         auto lastActivity = _clients[i]->getLastActivity();
         auto diff =
         std::chrono::duration_cast<std::chrono::seconds>(now - lastActivity);
-        if (diff.count() > 5) {
+        if (diff.count() > 30) {
             std::cout << "Client " << _clients[i]->getName() << " disconnected"
                       << std::endl;
             Network::data::DisconnectData disconnectData{};

--- a/server/ClientManager.cpp
+++ b/server/ClientManager.cpp
@@ -8,6 +8,7 @@
 #include "ClientManager.hpp"
 #include "DisconnectData.hpp"
 #include "PacketManager.hpp"
+#include "Server.hpp"
 
 RType::ClientManager::ClientManager()
 {
@@ -73,7 +74,7 @@ void RType::ClientManager::unregisterClient(const udp::endpoint &endpoint)
     }
 }
 
-bool RType::ClientManager::cleanupInactiveClients(std::vector<Network::Packet> &packets)
+bool RType::ClientManager::cleanupInactiveClients(RType::Server &server)
 {
     bool isLeaderLoggedOut = false;
 
@@ -92,7 +93,7 @@ bool RType::ClientManager::cleanupInactiveClients(std::vector<Network::Packet> &
             std::unique_ptr<Network::Packet> disconnectPacket =
             Network::PacketManager::createPacket(Network::PacketType::DISCONNECT,
             &disconnectData);
-            packets.push_back(*disconnectPacket);
+            server.broadcast(*disconnectPacket);
             if (_clients[i]->isLeader())
                 isLeaderLoggedOut = true;
             _clients[i] = nullptr;

--- a/server/ClientManager.cpp
+++ b/server/ClientManager.cpp
@@ -6,6 +6,8 @@
 */
 
 #include "ClientManager.hpp"
+#include "DisconnectData.hpp"
+#include "PacketManager.hpp"
 
 RType::ClientManager::ClientManager()
 {
@@ -71,7 +73,7 @@ void RType::ClientManager::unregisterClient(const udp::endpoint &endpoint)
     }
 }
 
-bool RType::ClientManager::cleanupInactiveClients(void)
+bool RType::ClientManager::cleanupInactiveClients(std::vector<Network::Packet> &packets)
 {
     bool isLeaderLoggedOut = false;
 
@@ -85,6 +87,12 @@ bool RType::ClientManager::cleanupInactiveClients(void)
         if (diff.count() > 5) {
             std::cout << "Client " << _clients[i]->getName() << " disconnected"
                       << std::endl;
+            Network::data::DisconnectData disconnectData{};
+            disconnectData.id = i;
+            std::unique_ptr<Network::Packet> disconnectPacket =
+            Network::PacketManager::createPacket(Network::PacketType::DISCONNECT,
+            &disconnectData);
+            packets.push_back(*disconnectPacket);
             if (_clients[i]->isLeader())
                 isLeaderLoggedOut = true;
             _clients[i] = nullptr;

--- a/server/ClientManager.hpp
+++ b/server/ClientManager.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include "Client.hpp"
 #include "ConnectData.hpp"
+#include "Packet.hpp"
 
 namespace RType {
 
@@ -73,7 +74,7 @@ namespace RType {
              * @brief Unregister and disconnects all inactive clients.
              * Will replace the leader if the leader is inactive.
              */
-            bool cleanupInactiveClients(void);
+            bool cleanupInactiveClients(std::vector<Network::Packet> &packets);
 
             /**
              * @brief Set a new leader

--- a/server/ClientManager.hpp
+++ b/server/ClientManager.hpp
@@ -15,6 +15,8 @@
 
 namespace RType {
 
+    class Server;
+
     /**
      * @brief A ClientManager is a class that manages the clients connected to
      * the server.
@@ -74,7 +76,7 @@ namespace RType {
              * @brief Unregister and disconnects all inactive clients.
              * Will replace the leader if the leader is inactive.
              */
-            bool cleanupInactiveClients(std::vector<Network::Packet> &packets);
+            bool cleanupInactiveClients(RType::Server &server);
 
             /**
              * @brief Set a new leader

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -153,7 +153,7 @@ void RType::Server::broadcast(const Network::Packet &packet)
             std::unique_ptr<Network::Packet> disconnectPacket =
             Network::PacketManager::createPacket(Network::PacketType::DISCONNECT,
             &disconnectData);
-            packetManager.sendPacketsQueue.push_back(*disconnectPacket);
+            broadcast(*disconnectPacket);
             bool isLeader = client->isLeader();
             clientManager.unregisterClient(client->getEndpoint());
             if (isLeader) {
@@ -203,7 +203,7 @@ void RType::Server::_startClientCleanupTimer(boost::asio::io_service &ioService)
     _clientCleanupTimer->async_wait(
     [this, &ioService](const boost::system::error_code &ec) {
         if (!ec) {
-            if (this->clientManager.cleanupInactiveClients(packetManager.sendPacketsQueue)) {
+            if (this->clientManager.cleanupInactiveClients(*this)) {
                 if (this->clientManager.getLeader() == nullptr) {
                     this->clientManager.setNewLeader();
                     this->broadcastNewLeader();

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "Server.hpp"
+#include "DisconnectData.hpp"
 #include "LeaderData.hpp"
 
 RType::Server::Server(boost::asio::io_service &io_service, short port)
@@ -146,6 +147,13 @@ void RType::Server::broadcast(const Network::Packet &packet)
             // disconnected
             std::cout << "Client disconnected: " << client->getName()
                       << std::endl;
+            Network::data::DisconnectData disconnectData{};
+            disconnectData.id = i;
+
+            std::unique_ptr<Network::Packet> disconnectPacket =
+            Network::PacketManager::createPacket(Network::PacketType::DISCONNECT,
+            &disconnectData);
+            packetManager.sendPacketsQueue.push_back(*disconnectPacket);
             bool isLeader = client->isLeader();
             clientManager.unregisterClient(client->getEndpoint());
             if (isLeader) {
@@ -195,7 +203,7 @@ void RType::Server::_startClientCleanupTimer(boost::asio::io_service &ioService)
     _clientCleanupTimer->async_wait(
     [this, &ioService](const boost::system::error_code &ec) {
         if (!ec) {
-            if (this->clientManager.cleanupInactiveClients()) {
+            if (this->clientManager.cleanupInactiveClients(packetManager.sendPacketsQueue)) {
                 if (this->clientManager.getLeader() == nullptr) {
                     this->clientManager.setNewLeader();
                     this->broadcastNewLeader();

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -164,10 +164,10 @@ namespace RType {
             /**
              * @brief Global server timeout variable, defining the time before a client is considered inactive
              */
-            static constexpr int CLIENT_TIMEOUT_SECONDS = 10;
+            static constexpr int CLIENT_TIMEOUT_SECONDS = 30;
             /**
              * @brief Global server cleanup interval variable, defining the interval between each cleanup, used by the cleanup timer
              */
-            static constexpr int CLIENT_CLEANUP_INTERVAL_SECONDS = 5;
+            static constexpr int CLIENT_CLEANUP_INTERVAL_SECONDS = 15;
     };
 } // namespace RType

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -164,10 +164,10 @@ namespace RType {
             /**
              * @brief Global server timeout variable, defining the time before a client is considered inactive
              */
-            static constexpr int CLIENT_TIMEOUT_SECONDS = 180000;
+            static constexpr int CLIENT_TIMEOUT_SECONDS = 10;
             /**
              * @brief Global server cleanup interval variable, defining the interval between each cleanup, used by the cleanup timer
              */
-            static constexpr int CLIENT_CLEANUP_INTERVAL_SECONDS = 10000;
+            static constexpr int CLIENT_CLEANUP_INTERVAL_SECONDS = 5;
     };
 } // namespace RType


### PR DESCRIPTION
## Description
Add timeout managment and quit broadcasting

## Lien tache Jira
None

## Changement
Add timeout managment
Add quit broadcast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new player disconnection handling system.
- **Bug Fixes**
	- Adjusted client inactivity threshold from 5 seconds to 30 seconds to prevent premature disconnections.
- **Refactor**
	- Renamed `ConnectData` to `DisconnectData` to better represent its function.
- **Chores**
	- Updated various function parameters and global variables for improved performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->